### PR TITLE
news font changed to Poppins

### DIFF
--- a/labs/news/css/styles.css
+++ b/labs/news/css/styles.css
@@ -13,7 +13,7 @@ html {
 }
 
 body {
-  font-family: sans-serif;
+  font-family:poppins,sans-serif;
   background-color: var(--light-color);
 }
 


### PR DESCRIPTION
Font in the news section is changed to Poppins with  sans-serif as a fallback font.